### PR TITLE
Added config.schema.json to allow  easy configuration  in Homebridge Config UI X

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,256 @@
+{
+    "pluginAlias": "DoorBird",
+    "pluginType": "platform",
+    "singular": true,
+    "headerDisplay": "Doorbird Video Stations are exposed to HomeKit as separate accessories and each needs to be manually paired.\n\n1. Open the Home <img src='https://user-images.githubusercontent.com/3979615/78010622-4ea1d380-738e-11ea-8a17-e6a465eeec35.png' height='16.42px'> app on your device.\n2. Tap the Home tab, then tap <img src='https://user-images.githubusercontent.com/3979615/78010869-9aed1380-738e-11ea-9644-9f46b3633026.png' height='16.42px'>.\n3. Tap *Add Accessory*, and select *I Don't Have a Code or Cannot Scan*.\n4. Enter the Homebridge PIN, this can be found under the QR code in Homebridge UI or your Homebridge logs, alternatively you can select *Use Camera* and scan the QR code again.\n\nFor help and examples of common configurations please read the [wiki](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki).",
+    "footerDisplay": "The **ffmpeg** binary must be installed on your system for this plugin to work.",
+    "schema": {
+        "name": {
+            "title": "Name",
+            "type": "string"
+        },
+        "videoProcessor": {
+            "title": "Video Processor",
+            "type": "string"
+        },
+        "interfaceName": {
+            "title": "Interface Name",
+            "type": "string"
+        },
+        "cameras": {
+            "type": "array",
+            "items": {
+                "title": "Door Video Station w/ Camera",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "title": "Name of Station",
+                        "type": "string",
+                        "placeholder": "Enter Doorbird Video Station name...",
+                        "required": true
+                    },
+                    "doorbird_ip": {
+                        "title": "Door Bird IP",
+                        "placeholder": "Enter Doorbird Video Station ip address",
+                        "type": "string",
+                        "required": true,
+                        "format": "ipv4"
+                    },
+                    "doorbird_username": {
+                        "type": "string",
+                        "placeholder": "Enter Doorbird Video Station username",
+                        "required": true
+                    },
+                    "doorbird_password": {
+                        "type": "string",
+                        "placeholder": "Enter Doorbird Video Station password",
+                        "required": true
+                    },
+                    "relay_no": {
+                        "title": "Relay No",
+                        "placeholder": "Relay in video door station (1 or 2)",
+                        "default": "1",
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "use_peripheral": {
+                        "title": "Activate to use lock/unlock relay on peripheral instead of relay in video door station",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "peripheral_name": {
+                        "title": "The name of the peripheral controller or station",
+                        "placeholder": "gggggg",
+                        "type": "string"
+                    },
+                    "peripheral_relay_no": {
+                        "title": "Relay no on device",
+                        "placeholder": "Relay number in peripheral",
+                        "default": "1",
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "cmd_doorbell": {
+                        "type": "string"
+                    },
+                    "cmd_motionsensor": {
+                        "type": "string"
+                    },
+                    "videoConfig": {
+                        "title": "Video Configuration",
+                        "type": "object",
+                        "properties": {
+                            "source": {
+                                "title": "Source",
+                                "type": "string",
+                                "default": "-rtsp_transport tcp -re -i rtsp://xxxusername:xxxpassword@xxx.xxx.xxx:8557/mpeg/media.amp",
+                                "placeholder": "-rtsp_transport tcp -re -i rtsp://xxxusername:xxxpassword@xxx.xxx.xxx:8557/mpeg/media.amp",
+                                "required": true
+                            },
+                            "stillImageSource": {
+                                "title": "Still Image Source",
+                                "default": "-i http://xxx.xxx.xxx.xxx:80/bha-api/image.cgi?http-user=xxx&http-password=xxx",
+                                "placeholder": "-i http://xxx.xxx.xxx.xxx:80/bha-api/image.cgi?http-user=xxx&http-password=xxx",
+                                "type": "string"
+                            },
+                            "maxStreams": {
+                                "title": "Maximum Number of Streams",
+                                "type": "integer",
+                                "default": 2,
+                                "minimum": 1,
+                                "description": "The maximum number of streams that will be generated for this camera"
+                            },
+                            "maxWidth": {
+                                "title": "Maximum Width",
+                                "type": "integer",
+                                "default": 1280,
+                                "minimum": 1,
+                                "description": "The maximum width reported to HomeKit"
+                            },
+                            "maxHeight": {
+                                "title": "Maximum Height",
+                                "type": "integer",
+                                "default": 720,
+                                "minimum": 1,
+                                "description": "The maximum height reported to HomeKit"
+                            },
+                            "maxFPS": {
+                                "title": "Maximum FPS",
+                                "type": "integer",
+                                "default": 15,
+                                "description": "The maximum frame rate of the stream"
+                            },
+                            "maxBitrate": {
+                                "title": "Maximum Bitrate",
+                                "type": "integer",
+                                "placeholder": 300,
+                                "minimum": 1,
+                                "description": "The maximum bit rate of the stream"
+                            },
+                            "preserveRatio": {
+                                "title": "Preserve Ratio",
+                                "type": "string",
+                                "description": "Can be set to either 'W' or 'H' with respective obvious meanings.",
+                                "typeahead": {
+                                    "source": [
+                                        "W",
+                                        "H"
+                                    ]
+                                }
+                            },
+                            "vcodec": {
+                                "title": "Video Codec",
+                                "type": "string",
+                                "placeholder": "libx264",
+                                "description": "The ffmpeg video processing codec to use.",
+                                "typeahead": {
+                                    "source": [
+                                        "libx264",
+                                        "copy",
+                                        "h264_omx",
+                                        "h264",
+                                        "h264_mmal"
+                                    ]
+                                }
+                            },
+                            "packetSize": {
+                                "title": "Packet Size",
+                                "type": "number",
+                                "placeholder": 1316,
+                                "multipleOf": 188.0
+                            },
+                            "videoFilter": {
+                                "title": "Allows a custom video filter to be passed to FFmpeg via -vf",
+                                "type": "string",
+                                "placeholder": "scale=1280:720"
+                            },
+                            "additionalCommandline": {
+                                "title": "Additional of extra command line options",
+                                "type": "string",
+                                "description": "Additional of extra command line options to use with FFmpeg, for example '-loglevel verbose'"
+                            },
+                            "mapvideo": {
+                                "type": "string",
+                                "title": "Map Video",
+                                "placeholder": "0:0",
+                                "description": " Select the stream used for video"
+                            },
+                            "mapaudio": {
+                                "type": "string",
+                                "title": "Map Audio",
+                                "placeholder": "0:1",
+                                "description": " Select the stream used for audio"
+                            },
+                            "audio": {
+                                "title": "Enable Audio (requires ffmpeg with libfdk-aac)",
+                                "type": "boolean"
+                            },
+                            "vflip": {
+                                "title": "Flip Stream Vertically",
+                                "type": "boolean"
+                            },
+                            "hflip": {
+                                "title": "Flip Stream Horizontally",
+                                "type": "boolean"
+                            },
+                            "debug": {
+                                "title": "Enable Debug Mode",
+                                "type": "boolean"
+                            },
+                            "port": {
+                                "title": "Port of homebridge-doorbird HTTP Server for callbacks",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "layout": [
+        {
+            "key": "cameras",
+            "title": "Doorbird Video Station",
+            "type": "array",
+            "orderable": false,
+            "buttonText": "Add Video Door Station",
+            "items": [
+                "cameras[].name",
+                "cameras[].doorbird_ip",
+                "cameras[].doorbird_username",
+                "cameras[].doorbird_password",
+                "cameras[].videoConfig.source",
+                "cameras[].videoConfig.stillImageSource",
+                "cameras[].relay_no",
+                "cameras[].use_peripheral",
+                "cameras[].peripheral_name",
+                "cameras[].peripheral_relay_no",
+                "cameras[].cmd_doorbell",
+                "cameras[].cmd_motion",
+                "cameras[].videoConfig.port",
+                {
+                    "key": "cameras[].videoConfig",
+                    "type": "section",
+                    "title": "Advanced FFmpeg Video Settings",
+                    "expandable": true,
+                    "expanded": false,
+                    "items": [
+                        "cameras[].videoConfig.maxStreams",
+                        "cameras[].videoConfig.maxWidth",
+                        "cameras[].videoConfig.maxHeight",
+                        "cameras[].videoConfig.maxFPS",
+                        "cameras[].videoConfig.maxBitrate",
+                        "cameras[].videoConfig.preserveRatio",
+                        "cameras[].videoConfig.packetSize",
+                        "cameras[].videoConfig.videoFilter",
+                        "cameras[].videoConfig.additionalCommandline",
+                        "cameras[].videoConfig.mapvideo",
+                        "cameras[].videoConfig.mapaudio",
+                        "cameras[].videoConfig.vflip",
+                        "cameras[].videoConfig.hflip"
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Hi @brownad,
I copied the ffmpeg Homebridge Config UI X config.schema.json and adjusted it to fit the needs of homebridge-doorbird. Seems to work fine. 
Thanks @oznu, @dewgew for the nice base / work.

_It might be a good idea to change the config structure: _cmds_ and _peripherals_ should go in a separate section. This would allow to put them in the Config UI in separate section like the advanced video settings. In addition it would keep future extensions like inputs or multiple relay actions/services niely together. 
... but it would break current settings, requiring a migration path._

![image](https://user-images.githubusercontent.com/1259816/81101015-bf985600-8f0d-11ea-8568-77618f23c549.png)
