### PR TITLE
Full relay support. Update platform name. Correct name issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ This step is not required. For those that prefer to tailor the defaults to their
     "platform": "Doorbird",
     "name": "Doorbird",
     "videoProcessor": "/usr/local/bin/ffmpeg",
-    "port": 5005,
     "debug": no,
 
     "cameras": [
@@ -108,17 +107,18 @@ This step is not required. For those that prefer to tailor the defaults to their
         "username": "some-doorbird-user (or create a new one just for homebridge)",
         "password": "some-doorbird-password",
         "audio": true,
+        "defaultRelay": "1",
         "cmdDoorbell": "/some/doorbell/script",
         "cmdMotion": "/some/motion/script",
-        "defaultRelay": 1
+        "port": 5005
       }
     ],
     
     "videoConfig": {
       "additionalCommandline": "-preset slow -profile:v high -level 4.2 -x264-params intra-refresh=1:bframes=0",
-      "maxStreams": 4
-      "maxWidth": 1280
-      "maxHeight": 720
+      "maxStreams": 4,
+      "maxWidth": 1280,
+      "maxHeight": 720,
       "maxFPS": 15,
       "packetSize": 376
     }
@@ -131,9 +131,8 @@ Platform-level configuration parameters:
 | Fields                 | Description                                             | Default                                                                               | Required |
 |------------------------|---------------------------------------------------------|---------------------------------------------------------------------------------------|----------|
 | platform               | Must always be `Doorbird`.                              |                                                                                       | Yes      |
-| name                   | For logging purposes.                                   |                                                                                       | No       |
+| name                   | Name to use for the Doorbird platform.                  |                                                                                       | No       |
 | videoProcessor         | Specify path of ffmpeg or avconv.                       | "ffmpeg"                                                                              | No       |
-| port                   | Port to use for the plugin webserver for notifications. | 5005                                                                                  | No       |
 | debug                  | Enable additional debug logging.                        | no                                                                                    | No       |
 
 Camera-level configuration parameters:
@@ -143,16 +142,18 @@ Camera-level configuration parameters:
 | doorbird               | IP address of your Doorbird                             |                                                                                       | Yes      |
 | username               | Your Doorbird username.                                 |                                                                                       | Yes      |
 | password               | Your Doorbird password.                                 |                                                                                       | Yes      |
+| name                   | Name to use for this Doorbird.                          |                                                                                       | No       |
+| audio                  | Enable audio support for Doorbird.                      | no                                                                                    | No       |
 | cmdDoorbell            | Command line to execute when a doorbell event is triggered. |                                                                                   | No       |
 | cmdMotion              | Command line to execute when a motion event is triggered. |                                                                                     | No       |
-| defaultRelay           | Default relay to use for doorbell lock events.          | 1                                                                                     | No       |
+| defaultRelay           | Default relay to use for doorbell lock events.          | "1"                                                                                   | No       |
 | additionalCommandline  | Additional parameters to pass ffmpeg to render video.   | "-preset slow -profile:v high -level 4.2 -x264-params intra-refresh=1:bframes=0"      | No       |
+| packetSize             | Packet size for the camera stream in multiples of 188.  | 376                                                                                   | No       |
 | maxStreams             | Maximum number of streams allowed for a camera.         | 4                                                                                     | No       |
 | maxWidth               | Maximum width of a video stream allowed.                | 1280                                                                                  | No       |
 | maxHeight              | Maximum height of a video stream allowed.               | 720                                                                                   | No       |
 | maxFPS                 | Maximum framerate for a video stream.                   | 15                                                                                    | No       |
-| packetSize             | Packet size for the camera stream in multiples of 188.  | 376                                                                                   | No       |
-| audio                  | Enable audio support for Doorbird.                      | no                                                                                    | No       |
+| port                   | Port to use for the plugin webserver for notifications. | 5005                                                                                  | No       |
 
 ## Credits
 * [homebridge-videodoorbell](https://github.com/Samfox2/homebridge-videodoorbell)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This step is not required. For those that prefer to tailor the defaults to their
     "platform": "Doorbird",
     "name": "Doorbird",
     "videoProcessor": "/usr/local/bin/ffmpeg",
-    "debug": no,
+    "debug": false,
 
     "cameras": [
       {
@@ -116,11 +116,11 @@ This step is not required. For those that prefer to tailor the defaults to their
     
     "videoConfig": {
       "additionalCommandline": "-preset slow -profile:v high -level 4.2 -x264-params intra-refresh=1:bframes=0",
+      "packetSize": 376,
       "maxStreams": 4,
       "maxWidth": 1280,
       "maxHeight": 720,
-      "maxFPS": 15,
-      "packetSize": 376
+      "maxFPS": 15
     }
   }
 ]
@@ -133,27 +133,32 @@ Platform-level configuration parameters:
 | platform               | Must always be `Doorbird`.                              |                                                                                       | Yes      |
 | name                   | Name to use for the Doorbird platform.                  |                                                                                       | No       |
 | videoProcessor         | Specify path of ffmpeg or avconv.                       | "ffmpeg"                                                                              | No       |
-| debug                  | Enable additional debug logging.                        | no                                                                                    | No       |
+| debug                  | Enable additional debug logging.                        | false                                                                                 | No       |
 
-Camera-level configuration parameters:
+`cameras` configuration parameters:
 
 | Fields                 | Description                                             | Default                                                                               | Required |
 |------------------------|---------------------------------------------------------|---------------------------------------------------------------------------------------|----------|
+| name                   | Name to use for this Doorbird.                          |                                                                                       | No       |
 | doorbird               | IP address of your Doorbird                             |                                                                                       | Yes      |
 | username               | Your Doorbird username.                                 |                                                                                       | Yes      |
 | password               | Your Doorbird password.                                 |                                                                                       | Yes      |
-| name                   | Name to use for this Doorbird.                          |                                                                                       | No       |
-| audio                  | Enable audio support for Doorbird.                      | no                                                                                    | No       |
+| audio                  | Enable audio support for Doorbird.                      | false                                                                                 | No       |
+| defaultRelay           | Default relay to use for doorbell lock events.          | "1"                                                                                   | No       |
 | cmdDoorbell            | Command line to execute when a doorbell event is triggered. |                                                                                   | No       |
 | cmdMotion              | Command line to execute when a motion event is triggered. |                                                                                     | No       |
-| defaultRelay           | Default relay to use for doorbell lock events.          | "1"                                                                                   | No       |
+| port                   | Port to use for the plugin webserver for notifications. | 5005                                                                                  | No       |
+
+`videoConfig` configuration parameters:
+
+| Fields                 | Description                                             | Default                                                                               | Required |
+|------------------------|---------------------------------------------------------|---------------------------------------------------------------------------------------|----------|
 | additionalCommandline  | Additional parameters to pass ffmpeg to render video.   | "-preset slow -profile:v high -level 4.2 -x264-params intra-refresh=1:bframes=0"      | No       |
 | packetSize             | Packet size for the camera stream in multiples of 188.  | 376                                                                                   | No       |
 | maxStreams             | Maximum number of streams allowed for a camera.         | 4                                                                                     | No       |
 | maxWidth               | Maximum width of a video stream allowed.                | 1280                                                                                  | No       |
 | maxHeight              | Maximum height of a video stream allowed.               | 720                                                                                   | No       |
 | maxFPS                 | Maximum framerate for a video stream.                   | 15                                                                                    | No       |
-| port                   | Port to use for the plugin webserver for notifications. | 5005                                                                                  | No       |
 
 ## Credits
 * [homebridge-videodoorbell](https://github.com/Samfox2/homebridge-videodoorbell)

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,5 +1,5 @@
 {
-    "pluginAlias": "DoorBird",
+    "pluginAlias": "Doorbird",
     "pluginType": "platform",
     "singular": true,
     "headerDisplay": "Doorbird Video Stations are exposed to HomeKit as separate accessories and each needs to be manually paired.\n\n1. Open the Home <img src='https://user-images.githubusercontent.com/3979615/78010622-4ea1d380-738e-11ea-8a17-e6a465eeec35.png' height='16.42px'> app on your device.\n2. Tap the Home tab, then tap <img src='https://user-images.githubusercontent.com/3979615/78010869-9aed1380-738e-11ea-9644-9f46b3633026.png' height='16.42px'>.\n3. Tap *Add Accessory*, and select *I Don't Have a Code or Cannot Scan*.\n4. Enter the Homebridge PIN, this can be found under the QR code in Homebridge UI or your Homebridge logs, alternatively you can select *Use Camera* and scan the QR code again.\n\nFor help and examples of common configurations please read the [wiki](https://github.com/KhaosT/homebridge-camera-ffmpeg/wiki).",
@@ -9,68 +9,72 @@
             "title": "Name",
             "type": "string"
         },
+
         "videoProcessor": {
             "title": "Video Processor",
             "type": "string"
         },
-        "interfaceName": {
-            "title": "Interface Name",
-            "type": "string"
+
+        "port": {
+            "title": "Port",
+            "type": "integer"
         },
+        
         "cameras": {
             "type": "array",
             "items": {
-                "title": "Door Video Station w/ Camera",
+                "title": "Doorbird Configuration",
                 "type": "object",
                 "properties": {
                     "name": {
-                        "title": "Name of Station",
+                        "title": "Doorbird Name",
                         "type": "string",
-                        "placeholder": "Enter Doorbird Video Station name...",
+                        "placeholder": "Doorbird",
                         "required": true
                     },
+                    
                     "doorbird": {
                         "title": "DoorBird IP",
-                        "placeholder": "Enter Doorbird Video Station ip address",
+                        "placeholder": "Enter Doorbird Video Station IP address",
                         "type": "string",
                         "required": true,
                         "format": "ipv4"
                     },
+                    
                     "username": {
                         "type": "string",
                         "placeholder": "Enter Doorbird Video Station username",
                         "required": true
                     },
+                    
                     "password": {
                         "type": "string",
                         "placeholder": "Enter Doorbird Video Station password",
                         "required": true
                     },
-                    "relay": {
-                        "title": "Relay No",
-                        "placeholder": "Relay in video door station (1 or 2)",
-                        "default": "1",
-                        "type": "integer",
-                        "minimum": 1
-                    },
-                    "peripheralName": {
-                        "title": "The name of the peripheral controller or station",
-                        "placeholder": "gggggg",
-                        "type": "string"
-                    },
-                    "peripheralRelay": {
-                        "title": "Relay no on device",
-                        "placeholder": "Relay number in peripheral",
-                        "default": "1",
-                        "type": "integer",
-                        "minimum": 1
-                    },
+                    
                     "cmdDoorbell": {
+                        "title": "Command line to execute when a doorbell event is detected.",
                         "type": "string"
                     },
+                    
                     "cmdMotion": {
+                        "title": "Command line to execute when a motion event is detected.",
                         "type": "string"
                     },
+
+                    "defaultRelay": {
+                        "title": "Default relay to trigger for doorbell lock events.",
+                        "default": "1",
+                        "type": "string"
+                    },
+
+                    "port": {
+                        "title": "Port",
+                        "type": "number",
+                        "desciption": "Port to use for the Doorbird notification server."
+                    },
+
                     "videoConfig": {
                         "title": "Video Configuration",
                         "type": "object",
@@ -78,10 +82,11 @@
                             "maxStreams": {
                                 "title": "Maximum Number of Streams",
                                 "type": "integer",
-                                "default": 2,
+                                "default": 4,
                                 "minimum": 1,
                                 "description": "The maximum number of streams that will be generated for this camera"
                             },
+                            
                             "maxWidth": {
                                 "title": "Maximum Width",
                                 "type": "integer",
@@ -89,6 +94,7 @@
                                 "minimum": 1,
                                 "description": "The maximum width reported to HomeKit"
                             },
+                            
                             "maxHeight": {
                                 "title": "Maximum Height",
                                 "type": "integer",
@@ -96,34 +102,35 @@
                                 "minimum": 1,
                                 "description": "The maximum height reported to HomeKit"
                             },
+                            
                             "maxFPS": {
                                 "title": "Maximum FPS",
                                 "type": "integer",
                                 "default": 15,
                                 "description": "The maximum frame rate of the stream"
                             },
+                            
                             "packetSize": {
-                                "title": "Packet Size",
+                                "title": "Packet Size (in multiples of 188)",
                                 "type": "number",
-                                "placeholder": 1316,
+                                "default": 376,
                                 "multipleOf": 188.0
                             },
+                            
                             "additionalCommandline": {
-                                "title": "Additional of extra command line options",
+                                "title": "Additional command line options for ffmpeg",
                                 "type": "string",
-                                "description": "Additional of extra command line options to use with FFmpeg, for example '-loglevel verbose'"
+                                "description": "Additional command line options to use with FFmpeg, for example '-loglevel verbose'"
                             },
+                            
                             "audio": {
                                 "title": "Enable Audio (requires ffmpeg with libfdk-aac)",
                                 "type": "boolean"
                             },
+                            
                             "debug": {
                                 "title": "Enable Debug Mode",
                                 "type": "boolean"
-                            },
-                            "port": {
-                                "title": "Port of homebridge-doorbird HTTP Server for callbacks",
-                                "type": "number"
                             }
                         }
                     }
@@ -134,21 +141,20 @@
     "layout": [
         {
             "key": "cameras",
-            "title": "Doorbird Video Station",
+            "title": "Doorbird",
             "type": "array",
             "orderable": false,
-            "buttonText": "Add Video Door Station",
+            "buttonText": "Add Doorbird",
             "items": [
                 "cameras[].name",
                 "cameras[].doorbird",
                 "cameras[].username",
                 "cameras[].password",
-                "cameras[].relay",
-                "cameras[].peripheralName",
-                "cameras[].peripheralRelay",
+                "cameras[].videoConfig.audio",
+                "cameras[].defaultRelay",
                 "cameras[].cmdDoorbell",
                 "cameras[].cmdMotion",
-                "cameras[].videoConfig.port",
+                "cameras[].port",
                 {
                     "key": "cameras[].videoConfig",
                     "type": "section",

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ doorBirdPlatform.prototype.didFinishLaunching = function() {
 
       // Let's configure reasonable defaults for Doorbird.
       var videoConfig = self.config.videoConfig;
-      var webserverPort = self.config.port || 5005;
+      var webserverPort = cameraConfig.port || 5005;
 
       var source = '-re -rtsp_transport tcp -i rtsp://' + self.doorBirdAuth + ':8557/mpeg/media.amp';
       var stillImageSource = '-i http://' + self.doorBirdAuth + '/bha-api/image.cgi';

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var qs = require('querystring');
 var concat = require('concat-stream');
 var request = require('request');
 var exec = require('child_process').exec;
+var rp = require('request-promise');
 
 module.exports = function(homebridge) {
   Accessory = homebridge.platformAccessory;
@@ -15,7 +16,7 @@ module.exports = function(homebridge) {
   Characteristic = hap.Characteristic;
   UUIDGen = homebridge.hap.uuid;
 
-  homebridge.registerPlatform('homebridge-doorbird', 'DoorBird', doorBirdPlatform, true);
+  homebridge.registerPlatform('homebridge-doorbird', 'Doorbird', doorBirdPlatform, true);
 }
 
 function doorBirdPlatform(log, config, api) {
@@ -24,9 +25,6 @@ function doorBirdPlatform(log, config, api) {
   self.log = log;
   self.config = config || {};
   
-  // Assume initial lock state to secured until we learn otherwise.
-  self.currentState = Characteristic.LockCurrentState.SECURED;
-
   if(api) {
     self.api = api;
 
@@ -54,7 +52,7 @@ doorBirdPlatform.prototype = {
 };
 
 doorBirdPlatform.prototype.configureAccessory = function(accessory) {
-    // Won't be invoked
+    // Won't be invoked.
 }
 
 doorBirdPlatform.prototype.identify = function(primaryService, paired, callback) {
@@ -75,17 +73,26 @@ doorBirdPlatform.prototype.didFinishLaunching = function() {
     var cameras = self.config.cameras;
     
     cameras.forEach(function(cameraConfig) {
-      var cameraName = cameraConfig.name || 'Doorbird@' + cameraConfig.doorbird;
+      var doorBirdInfo = {};
+      var cameraName = cameraConfig.name || self.config.name || 'Doorbird';
 
+      // Debugging?
       self.debug = cameraConfig.debug === true;
+
+      // Required parameters to configure Doorbird.
       self.ip = cameraConfig.doorbird;
       self.username = cameraConfig.username;
       self.password = cameraConfig.password;
+
+      // Optional command line actions on certain events.
       self.cmdDoorbell = cameraConfig.cmdDoorbell;
       self.cmdMotion = cameraConfig.cmdMotion;
-      self.peripheral = cameraConfig.peripheral;
-      self.peripheralRelay = cameraConfig.peripheralRelay;
-      self.relay = cameraConfig.relay;
+
+      // Initialize the array of relays.
+      self.lockService = {};
+      self.lockState = {};
+      self.lockUrl = {};
+      self.primaryRelay = 0;
 
       // You must specify at least the IP of the Doorbird,
       // a username, and a password.
@@ -100,21 +107,6 @@ doorBirdPlatform.prototype.didFinishLaunching = function() {
       // Set the night light URL.
       self.lightUrl = 'http://' + self.doorBirdAuth + '/bha-api/light-on.cgi?';
 
-       // Handle peripherals and relays other than the default.            
-      if(self.peripheral) {
-        self.log("Lock/unlock via peripheral %s with relay %s.", self.peripheral, self.peripheralRelay);
-        self.open = '/bha-api/open-door.cgi?r=' + self.peripheral + "@" + self.peripheralRelay;
-      } else if(self.relay) { // Use a different relay than the default.
-        self.log("Lock/unlock via relay %s in Doorbird.", self.relay);
-        self.open = '/bha-api/open-door.cgi?r=+' + self.relay;
-      } else {
-        self.log('No peripheral or relay configured will use the default relay (relay 1) in Door Station.');
-        self.open = '/bha-api/open-door.cgi?';
-      }
-      
-      // Set the unlock URL.
-      self.lockUrl = 'http://' + self.doorBirdAuth + self.open;
-     
       // Let's configure reasonable defaults for Doorbird.
       var videoConfig = self.config.videoConfig;
       var webserverPort = self.config.port || 5005;
@@ -130,7 +122,7 @@ doorBirdPlatform.prototype.didFinishLaunching = function() {
       var maxFPS = 15;
       var packetSize = 376;
       var videoDebug = false;
-
+      
       // Configure audio.
       if(cameraConfig.audio) {
         source += ' -f mulaw -ar 8000 -i http://' + self.doorBirdAuth + '/bha-api/audio-receive.cgi';
@@ -153,257 +145,293 @@ doorBirdPlatform.prototype.didFinishLaunching = function() {
           additionalCommandline = videoConfig.additionalCommandline;
         }
 
-        if(videoConfig.maxStreams) {
+        if(!videoConfig.maxStreams) {
           maxStreams = videoConfig.maxStreams;
         }
 
-        if(videoConfig.maxWidth) {
+        if(!videoConfig.maxWidth) {
           maxWidth = videoConfig.maxWidth;
         }
 
-        if(videoConfig.maxHeight) {
+        if(!videoConfig.maxHeight) {
           maxHeight = videoConfig.maxHeight;
         }
 
-        if(videoConfig.maxFPS) {
+        if(!videoConfig.maxFPS) {
           maxFPS = videoConfig.maxFPS;
         }
 
-        if(videoConfig.packetSize) {
+        if(!videoConfig.packetSize) {
           packetSize = videoConfig.packetSize;
         }
       }
-
-      var uuid = UUIDGen.generate(cameraName);
-      var doorBirdAccessory = new Accessory(cameraName, uuid, hap.Accessory.Categories.VIDEO_DOORBELL);
-
+      
       // Get Doorbird device information.
-      request.get({
-        url: 'http://' + self.doorBirdAuth + '/bha-api/info.cgi',
-      }, function(err, response, body) {
-        if(!err && response.statusCode == 200) {
-          let doorBirdReply = JSON.parse(response.body);
-          let doorBirdInfo = doorBirdReply.BHA.VERSION[0];
+      var rpOpts = {
+        uri: 'http://' + self.doorBirdAuth + '/bha-api/info.cgi',
+        json: true
+      };
           
+      rp(rpOpts)
+        .then(function(dbInfo) {
+          doorBirdInfo =  dbInfo.BHA.VERSION[0]; 
+          
+          // Use the MAC address to uniquely identify each Doorbird.
+          var doorBirdUUID = doorBirdInfo["PRIMARY_MAC_ADDR"] || doorBirdInfo["WIFI_MAC_ADDR"];
+
+          // Create the accessory.
+          var uuid = UUIDGen.generate(doorBirdUUID);
+          var doorBirdAccessory = new Accessory(cameraName, uuid, hap.Accessory.Categories.VIDEO_DOORBELL);
+
           // Set the accessory information.
           doorBirdAccessory.getService(hap.Service.AccessoryInformation)
             .setCharacteristic(hap.Characteristic.Manufacturer, 'Bird Home Automation GmbH')        
             .setCharacteristic(hap.Characteristic.Model, doorBirdInfo["DEVICE-TYPE"])
             .setCharacteristic(hap.Characteristic.FirmwareRevision, doorBirdInfo["FIRMWARE"] + '.' + doorBirdInfo["BUILD_NUMBER"])
             .setCharacteristic(hap.Characteristic.SerialNumber, doorBirdInfo["WIFI_MAC_ADDR"]);        
-        } else {
-          self.log("Unable to query the Doorbird. Error: %s. Response: %s", err, body);
-        }
-      });
+    
+          // Check to see what relays we have available to us and add them.
+          var relays = doorBirdInfo["RELAYS"];
+      
+          relays.forEach(function(doorBirdRelay) {                        
+            // Default to setting the primary relay to the first one unless configured otherwise.
+            if(!self.primaryRelay || cameraConfig.defaultRelay == doorBirdRelay) {
+              self.primaryRelay = doorBirdRelay;
+            }
+    
+            // Set the unlock URL.
+            self.lockUrl[doorBirdRelay] = 'http://' + self.doorBirdAuth +
+              '/bha-api/open-door.cgi?r=' + doorBirdRelay;
 
-      // Add the motion accessory.
-      var motionService = doorBirdAccessory.addService(Service.MotionSensor,  'Motion Sensor');
+            // Add the lock Accessory.
+            self.log("Detected relay: %s.", doorBirdRelay);
+            self.lockService[doorBirdRelay] = doorBirdAccessory.addService(Service.LockMechanism, 'Relay ' + doorBirdRelay, doorBirdRelay);
 
-      // Add the light accessory.
-      var lightService = doorBirdAccessory.addService(Service.Lightbulb, 'Light');
-
-      lightService.getCharacteristic(Characteristic.On)
-        .on('set', function(value, callback) {
-          
-          // If we're already on, don't allow us to be turned off until the timer runs out.
-          if(self.lightPoll) {
-            self.log("Doorbird night vision is already active.");
-            
-            setTimeout(function() {
-              lightService.getCharacteristic(Characteristic.On).updateValue(true);
-            }.bind(self), 10);
-            
-          } else {
-            request.get({
-              url: self.lightUrl,
-            }, function(err, response, body) {
-              if(!err && response.statusCode == 200) {
-                // Clear old countdowns first.
-                if(self.lightPoll) {
-                  clearTimeout(self.lightPoll);
-                }
-              
-                self.log('Doorbird night vision activated for 3 minutes.');
-
-                self.lightPoll = setTimeout(function() {
-                  lightService.getCharacteristic(Characteristic.On).updateValue(false);
-                  self.lightPoll = 0;
-                }.bind(self), 1000 * 60 * 3);
-              } else {
-                self.log("Doorbird error '%s' setting the light state. Response: %s", err, body);
-                callback(err || new Error('Error setting the light state.'));
-              }
-            });
-        }
-          
-        callback();
-      });
-
-      // Add the lock Accessory.
-      self.lockService = doorBirdAccessory.addService(Service.LockMechanism,  ' Lock');
-
-      // Configure LockMechanism.
-      self.lockService
-        .getCharacteristic(Characteristic.LockCurrentState)
-        .on('get', self.getState.bind(self));
-
-      self.lockService
-        .getCharacteristic(Characteristic.LockTargetState)
-        .on('get', self.getState.bind(self))
-        .on('set', self.setState.bind(self));
-
-      // Doorbell has to be the primary service.
-      var primaryService = new Service.Doorbell(cameraName);
-      primaryService.getCharacteristic(Characteristic.ProgrammableSwitchEvent).on('get', self.getState.bind(this));
-
-      // Setup and configure the camera services.
-      var doorbirdCamera = {
-        name: cameraName,
+            // Assume initial lock state to secured until we learn otherwise.
+            self.lockState[doorBirdRelay] = Characteristic.LockCurrentState.SECURED;
         
-        videoConfig: {
-          source: source,
-          stillImageSource: stillImageSource,
-          additionalCommandline: additionalCommandline,
-          maxStreams: maxStreams,
-          maxWidth: maxWidth,
-          maxHeight: maxHeight,
-          maxFPS: maxFPS,
-          packetSize: packetSize,
-          audio: audio,
-          mapaudio: mapaudio,
-          debug: videoDebug
-        }
-      };
+            // Configure LockMechanism.
+            self.lockService[doorBirdRelay]
+              .getCharacteristic(Characteristic.LockCurrentState)
+              .on('get', self.getState.bind(self, doorBirdRelay));
+           
+            self.lockService[doorBirdRelay]
+              .getCharacteristic(Characteristic.LockTargetState)
+              .on('get', self.getState.bind(self, doorBirdRelay))
+              .on('set', self.setState.bind(self, doorBirdRelay));
+          });
 
-      var cameraSource = new FFMPEG(hap, doorbirdCamera, self.log, videoProcessor);
-      doorBirdAccessory.configureCameraSource(cameraSource);
+          if(self.primaryRelay) {
+            self.log("Primary relay set to: %s.", self.primaryRelay);
+          }
 
-      // Setup HomeKit doorbell service
-      doorBirdAccessory.addService(primaryService);
+          // Add the motion accessory.
+          var motionService = doorBirdAccessory.addService(Service.MotionSensor,  'Motion Sensor');
 
-      // Identify
-      doorBirdAccessory.on('identify', self.identify.bind(this, primaryService));
+          // Add the light accessory.
+          var lightService = doorBirdAccessory.addService(Service.Lightbulb, 'Infrared Light');
 
-      //Add Services
-      var speakerService = new Service.Speaker('Speaker');
-      doorBirdAccessory.addService(speakerService);
+          lightService.getCharacteristic(Characteristic.On)
+            .on('set', function(value, callback) {
+          
+              // If we're already on, don't allow us to be turned off until the timer runs out.
+              if(self.lightPoll) {
+                self.log("Doorbird night vision is already active.");
+            
+                setTimeout(function() {
+                  lightService.getCharacteristic(Characteristic.On).updateValue(true);
+                }.bind(self), 10);
+            
+              } else {
+                request.get({
+                  url: self.lightUrl,
+                }, function(err, response, body) {
+                  if(!err && response.statusCode == 200) {
+                    // Clear old countdowns first.
+                    if(self.lightPoll) {
+                      clearTimeout(self.lightPoll);
+                    }
+              
+                    self.log('Doorbird infrared light activated for 3 minutes.');
 
-      var microphoneService = new Service.Microphone('Microphone');
-      doorBirdAccessory.addService(microphoneService);
+                    self.lightPoll = setTimeout(function() {
+                      lightService.getCharacteristic(Characteristic.On).updateValue(false);
+                      self.lightPoll = 0;
+                    }.bind(self), 1000 * 60 * 3);
+                  } else {
+                    self.log("Doorbird error '%s' setting the light state. Response: %s", err, body);
+                    callback(err || new Error('Error setting the light state.'));
+                  }
+                });
+            }
+          
+            callback();
+          });
 
-      configuredAccessories.push(doorBirdAccessory);
-
-      self.api.publishCameraAccessories('homebridge-doorbird', configuredAccessories);
-
-      var server = http.createServer(function(req, res) {
+          // Doorbell has to be the primary service.
+          var primaryService = new Service.Doorbell(cameraName);
+          primaryService.getCharacteristic(Characteristic.ProgrammableSwitchEvent)
+            .on('get', self.getState.bind(this, self.primaryRelay));        
       
-        if(req.url == '/doorbell.html') {
-          server.status_code = 204;
-          
-          res.writeHead(204, {'Content-Type': 'text/plain'});
-          res.end("GET 204 " + http.STATUS_CODES[204] + " " + req.url + "\nThe server successfully processed the request and is not returning any content.");
+          // Setup and configure the camera services.
+          var doorbirdCamera = {
+            name: cameraName,
+        
+            videoConfig: {
+              source: source,
+              stillImageSource: stillImageSource,
+              additionalCommandline: additionalCommandline,
+              maxStreams: maxStreams,
+              maxWidth: maxWidth,
+              maxHeight: maxHeight,
+              maxFPS: maxFPS,
+              packetSize: packetSize,
+              audio: audio,
+              mapaudio: mapaudio,
+              debug: videoDebug
+            }
+          };
 
-          // Tell HomeKit about the doorbell event.
-          self.log("Doorbird detected a doorbell ring.");
-          self.EventWithAccessory(doorBirdAccessory);
+          var cameraSource = new FFMPEG(hap, doorbirdCamera, self.log, videoProcessor);
+          doorBirdAccessory.configureCameraSource(cameraSource);
+
+          // Setup HomeKit doorbell service
+          doorBirdAccessory.addService(primaryService);
+
+          // Identify
+          doorBirdAccessory.on('identify', self.identify.bind(this, primaryService));
+
+          //Add Services
+          var speakerService = new Service.Speaker('Speaker');
+          doorBirdAccessory.addService(speakerService);
+
+          var microphoneService = new Service.Microphone('Microphone');
+          doorBirdAccessory.addService(microphoneService);
+
+          configuredAccessories.push(doorBirdAccessory);
+
+          self.api.publishCameraAccessories('homebridge-doorbird', configuredAccessories);
+
+          var server = http.createServer(function(req, res) {
+      
+            if(self.debug) {
+              self.log("Notification server URL: %s", req.url);
+            }
+        
+            if(req.url == '/doorbell.html') {
+              server.status_code = 204;
           
-          // Execute any command associated with ringing the doorbell.
-          if(self.cmdDoorbell) {
-            self.log("Executing doorbell command: %s.", self.cmdDoorbell);
-            exec(self.cmdDoorbell, function(error, stdout, stderr) {
-              // Command output is in stdout.
-              if(error) {
-                self.log(error);
+              res.writeHead(204, {'Content-Type': 'text/plain'});
+              res.end("GET 204 " + http.STATUS_CODES[204] + " " + req.url + "\nThe server successfully processed the request and is not returning any content.");
+
+              // Tell HomeKit about the doorbell event.
+              self.log("Doorbird detected a doorbell ring.");
+              self.EventWithAccessory(doorBirdAccessory);
+          
+              // Execute any command associated with ringing the doorbell.
+              if(self.cmdDoorbell) {
+                self.log("Executing doorbell command: %s.", self.cmdDoorbell);
+                exec(self.cmdDoorbell, function(error, stdout, stderr) {
+                  // Command output is in stdout.
+                  if(error) {
+                    self.log(error);
+                  }
+                });
               }
-            });
-          }
-        } else if(req.url == '/motion.html') {
-          server.status_code = 204;
+            } else if(req.url == '/motion.html') {
+              server.status_code = 204;
           
-          res.writeHead(204, {'Content-Type': 'text/plain'});
-          res.end("GET 204 " + http.STATUS_CODES[204] + " " + req.url + "\nThe server successfully processed the request and is not returning any content.");
+              res.writeHead(204, {'Content-Type': 'text/plain'});
+              res.end("GET 204 " + http.STATUS_CODES[204] + " " + req.url + "\nThe server successfully processed the request and is not returning any content.");
 
-          // Tell the sensor we've detected motion.
-          setTimeout(function() {
-            self.log('Doorbird detected motion.');
-            motionService.getCharacteristic(Characteristic.MotionDetected).updateValue(true);
-          }.bind(self), 10);
+              // Tell the sensor we've detected motion.
+              setTimeout(function() {
+                self.log('Doorbird detected motion.');
+                motionService.getCharacteristic(Characteristic.MotionDetected).updateValue(true);
+              }.bind(self), 10);
 
-          // Execute any command associated with motion detection.
-          if(self.cmdMotion) {
-            self.log("Executing motion command: %s.", self.cmdMotion);
+              // Execute any command associated with motion detection.
+              if(self.cmdMotion) {
+                self.log("Executing motion command: %s.", self.cmdMotion);
             
-            exec(self.cmdMotion, function(error, stdout, stderr) {
-              // Command output is in stdout.
-              if(error) {
-                self.log(error);
+                exec(self.cmdMotion, function(error, stdout, stderr) {
+                  // Command output is in stdout.
+                  if(error) {
+                    self.log(error);
+                  }
+                });
               }
-            });
-          }
 
-          // Reset the motion sensor after 5 seconds.
-          setTimeout(function() {
-            self.log('Doorbird resetting the motion event after 5 seconds.');
+              // Reset the motion sensor after 5 seconds.
+              setTimeout(function() {
+                self.log('Doorbird resetting the motion event after 5 seconds.');
             
-            motionService.getCharacteristic(Characteristic.MotionDetected).updateValue(false);
-          }.bind(self), 1000 * 5);
-        } else {
-          server.status_code = 404;
+                motionService.getCharacteristic(Characteristic.MotionDetected).updateValue(false);
+              }.bind(self), 1000 * 5);
+            } else {
+              server.status_code = 404;
           
-          res.writeHead(404, {'Content-Type': 'text/plain'});
-          res.end("GET 404 " + http.STATUS_CODES[404] + " " + req.url + "\nThe file cannot be found.");
+              res.writeHead(404, {'Content-Type': 'text/plain'});
+              res.end("GET 404 " + http.STATUS_CODES[404] + " " + req.url + "\nThe file cannot be found.");
           
-          self.log("HTTP Server: GET 404 " + http.STATUS_CODES[404] + " " + req.url);
-        }
+              self.log("HTTP Server: GET 404 " + http.STATUS_CODES[404] + " " + req.url);
+            }
+          });
+      
+          // Fire up the web server to listen to notifications from Doorbird.
+          server.listen(webserverPort, function() {
+            self.log("%s is listening on port %s.", cameraName, webserverPort);
+          }.bind(this));
+            server.on('error', function(err) {
+              self.log("%s (port %s) error: %s.", cameraName, webserverPort, err);
+          }.bind(this));
+        })
+      .catch(function(error) {
+        self.log("Unable to query the Doorbird: " + error);
       });
-      
-      // Fire up the web server to listen to notifications from Doorbird.
-      server.listen(webserverPort, function() {
-        self.log("%s is listening on port %s.", cameraName, webserverPort);
-      }.bind(this));
-        server.on('error', function (err) {
-          self.log("%s (port %s) error: %s.", cameraName, webserverPort, err);
-      }.bind(this));
     });
   }
 }
 
-doorBirdPlatform.prototype.getState = function (callback) {
-  callback(null, this.currentState);
+doorBirdPlatform.prototype.getState = function(relayIndex, callback) {
+  callback(null, this.lockState[relayIndex]);
 }
 
-doorBirdPlatform.prototype.setState = function (state, callback) {
+doorBirdPlatform.prototype.setState = function(relayIndex, state, callback) {
   var lockState = (state == Characteristic.LockTargetState.SECURED) ? "locking" : "unlocking";
   var updateState = (state == Characteristic.LockTargetState.SECURED) ? true : false;
   
   self = this;
   
-  self.log("Doorbird %s.", lockState);
-  self.currentState = (state == Characteristic.LockTargetState.SECURED) ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED;
+  if(self.debug) {
+    self.log("Doorbird relay %s %s.", relayIndex, lockState);
+  }
+  
+  self.lockState[relayIndex] = (state == Characteristic.LockTargetState.SECURED) ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED;
 
   if(lockState == "unlocking") {
     request.get({
-      url: self.lockUrl,
+      url: self.lockUrl[relayIndex],
     }, function(err, response, body) {
       if(!err && response.statusCode == 200) {
         // Set state to unlocked.
-        self.lockService
-          .setCharacteristic(Characteristic.LockCurrentState, self.currentState);
+        self.lockService[relayIndex]
+          .setCharacteristic(Characteristic.LockCurrentState, self.lockState[relayIndex]);
 
-        self.log('Doorbird unlocked.');
+        self.log('Doorbird relay %s unlocked.', relayIndex);
 
         if(!updateState) {
           setTimeout(function() {
             // Set state to unlocked, and relock in 5 seconds.
-            self.lockService
+            self.lockService[relayIndex]
               .setCharacteristic(Characteristic.LockTargetState, Characteristic.LockTargetState.SECURED)
-              .setCharacteristic(Characteristic.LockCurrentState, self.currentState);
+              .setCharacteristic(Characteristic.LockCurrentState, self.lockState[relayIndex]);
             updateState = true;
-            self.log('Doorbird locked (auto initiated after 5 seconds).');
+            self.log('Doorbird relay %s locked (auto initiated after 5 seconds).', relayIndex);
           }.bind(this), 1000 * 5);
         }
       } else {
-        self.log("Doorbird error '%s' opening lock. Response: %s", err, body);
+        self.log("Doorbird error '%s' opening relay %s. Response: %s", err, relayIndex, body);
         callback(err || new Error("Doorbird error setting the lock state."));
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-doorbird",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "DoorBird plugin for homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [
@@ -24,6 +24,7 @@
     "child_process": "^1.0.2",
     "http": "0.0.0",
     "request": "2.88.0",
+    "request-promise": "^4.2.4",
     "google-auth-library": "^0.10.0",
     "googleapis": "^18.0.0",
     "ip": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "http": "0.0.0",
     "request": "2.88.0",
     "request-promise": "^4.2.4",
-    "google-auth-library": "^0.10.0",
-    "googleapis": "^18.0.0",
     "ip": "^1.1.3",
     "debug": "^2.2.0",
     "concat-stream": "^1.6.0"


### PR DESCRIPTION
One day later, I've finished the last of the rewrite to provide dynamic relay support.

Now, when we launch, we query the Doorbird and enumerate all the relays available and make them accessible to users. This requires a change in configuration options...simplifying the plugin further. The only configuration option one needs to touch now is `defaultRelay` if you want to change which relay is triggered by the default unlock event.

Finally - the crazy name bug issue has been eliminated. The crux of the issue was how UUIDs are generated in the plugin. We now use the MAC address of the Doorbird to ensure we have a unique name to generate a unique UUID. Otherwise, we will have name collisions. **This will necessitate having to delete and re-add the Doorbird accessory in the Home app to adjust to this new method of deriving unique Doorbird IDs.**

I've bumped the version number up to reflect the breaking changes to configuration here...and just to make sure, I changed the platform name slightly, to facilitate people updating their configs.

After this...we tackle microphone support. Now that the other pieces are place, it's time to tackle this one.
