### PR TITLE
Add feature options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Feature options allow you to enable or disable certain features in this plugin. 
 The feature options for individual Doorbird devices can be customized using the `options` setting inside the `doorbirds` section. Available options:
 
 * <CODE>Relay.Hide.<I>relay</I></CODE> - hide the relay named *relay* from being shown in HomeKit.
-
+* <CODE>NightVision.Hide</CODE> - hide the night vision accessory from being shown in HomeKit (note that you won't be able to manually control the infrared light, see [Night vision](#night-vision) to automatically turn on the night vision).
 ### Night vision
 Depending on your situation, you might benefit from having Doorbird's infrared light (aka night vision) turn on automatically for you.
 


### PR DESCRIPTION
Hi,

I don't have any devices connected to my Doorbird relays. So I would like to hide every lock mechanism accessory but, in the current version, it isn't allowed to disable every relay because the bridge need a primary relay, but the variable where it's stored seemed to be never used afterwards... So I commented the code that check if there is one and it seemed to work normally on D2101KV.

I added the _NightVision.Hide_ option to hide the lightbulb accessory. Unfortunately, HomeKit doesn't provide a more proper way to control infrared light of a camera. I use _nightVision...Night_ option to automatically control the night vision, as Netatmo cameras do natively. So, it may be a good idea to add this option.